### PR TITLE
Add rss.xml tests

### DIFF
--- a/app/rss.xml/tests/route.test.ts
+++ b/app/rss.xml/tests/route.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/app/posts/actions', () => ({
   fetchPublishedPosts: vi.fn().mockResolvedValue([]),
 }))
 
-describe.skip('rss.xml', () => {
+describe('rss.xml', () => {
   describe('GET', () => {
     const mockDateTime = new Date(2024, 10, 31)
 

--- a/app/rss.xml/tests/route.test.ts
+++ b/app/rss.xml/tests/route.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/app/posts/actions', () => ({
 
 describe('rss.xml', () => {
   describe('GET', () => {
-    const mockDateTime = new Date(2024, 10, 31)
+    const mockDateTime = new Date(2024, 9, 31) // happy halloween 🎃
 
     beforeAll(() => {
       vi.useFakeTimers()
@@ -21,6 +21,7 @@ describe('rss.xml', () => {
     afterAll(() => {
       vi.useRealTimers()
     })
+
     it('returns properly formatted atom+xml rss response', async () => {
       const response = await GET()
       const blob = await response.blob()
@@ -38,7 +39,7 @@ describe('rss.xml', () => {
       expect(text).toContain(`<managingEditor><![CDATA[${EMAIL}]]></managingEditor>`)
       expect(text).toContain(`<webMaster><![CDATA[${EMAIL}]]></webMaster>`)
       expect(text).toContain(`<language><![CDATA[en-us]]></language>`)
-      expect(text).toContain(`<pubDate>Sun, 01 Dec 2024 07:00:00 GMT</pubDate>`)
+      expect(text).toContain(`<pubDate>Thu, 31 Oct 2024 06:00:00 GMT</pubDate>`)
       SITE_MAP_CATEGORIES.forEach((category) => {
         expect(text).toContain(`<category><![CDATA[${category}]]></category>`)
       })

--- a/app/rss.xml/tests/route.test.ts
+++ b/app/rss.xml/tests/route.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/app/posts/actions', () => ({
 
 describe('rss.xml', () => {
   describe('GET', () => {
-    const mockDateTime = new Date(2024, 9, 31) // happy halloween 🎃
+    const mockDateTime = new Date(Date.UTC(2024, 9, 31, 0, 0, 0)) // happy halloween 🎃
 
     beforeAll(() => {
       vi.useFakeTimers()
@@ -39,7 +39,7 @@ describe('rss.xml', () => {
       expect(text).toContain(`<managingEditor><![CDATA[${EMAIL}]]></managingEditor>`)
       expect(text).toContain(`<webMaster><![CDATA[${EMAIL}]]></webMaster>`)
       expect(text).toContain(`<language><![CDATA[en-us]]></language>`)
-      expect(text).toContain(`<pubDate>Thu, 31 Oct 2024 06:00:00 GMT</pubDate>`)
+      expect(text).toContain(`<pubDate>Thu, 31 Oct 2024 00:00:00 GMT</pubDate>`)
       SITE_MAP_CATEGORIES.forEach((category) => {
         expect(text).toContain(`<category><![CDATA[${category}]]></category>`)
       })

--- a/app/tests/sitemap.test.ts
+++ b/app/tests/sitemap.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/app/posts/actions', () => ({
 }))
 
 describe('sitemap', () => {
-  const mockDateTime = new Date(2024, 10, 31) // happy halloween
+  const mockDateTime = new Date(2024, 9, 31) // happy halloween 🎃
 
   beforeEach(() => {
     vi.setSystemTime(mockDateTime)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text', 'json-summary', 'json'],
       thresholds: {
-        statements: 60,
+        statements: 65,
         branches: 60,
-        functions: 60,
-        lines: 60,
+        functions: 65,
+        lines: 65,
       },
       exclude: [
         'components/ui/**', // ignore shadcn directory


### PR DESCRIPTION
## Brief Context

- Adds back in the skipped rss.xml tests
- Ups the ante on coverage reqs because of prev bullet
