### PR TITLE
Jameswalsh/jdub 31 migrate to new posthog setup

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,13 @@ import './globals.css'
 import { GeistMono } from 'geist/font/mono'
 import { GeistSans } from 'geist/font/sans'
 import { Metadata } from 'next'
+import dynamic from 'next/dynamic'
 import { PropsWithChildren } from 'react'
 
-import PostHogPageView from './PostHogPageView'
+const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
+  ssr: false,
+})
+
 import { AnalyticsProvider } from './providers'
 
 import Footer from '@/components/app-shell/footer'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistSans } from 'geist/font/sans'
 import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 
+import PostHogPageView from './PostHogPageView'
 import { AnalyticsProvider } from './providers'
 
 import Footer from '@/components/app-shell/footer'
@@ -27,22 +28,21 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: PropsWithChildren) {
   return (
-    <>
-      <html lang="en" className={cn(`${GeistSans.variable} ${GeistMono.variable}`, 'dark scroll-smooth')}>
-        <AnalyticsProvider>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <meta
-            name="ahrefs-site-verification"
-            content="91e1441f7228c69eeb9367bfbbda2c6284d19816253d8178d9087f42f95ab801"
-          />
-          <body className="flex w-screen flex-col md:items-center">
-            <TopNavbar />
-            <main className="mt-4 flex flex-col px-6 py-10 sm:px-4 md:w-[768px]">{children}</main>
-            <Footer />
-          </body>
-        </AnalyticsProvider>
-      </html>
-    </>
+    <html lang="en" className={cn(`${GeistSans.variable} ${GeistMono.variable}`, 'dark scroll-smooth')}>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="ahrefs-site-verification"
+        content="91e1441f7228c69eeb9367bfbbda2c6284d19816253d8178d9087f42f95ab801"
+      />
+      <AnalyticsProvider>
+        <body className="flex w-screen flex-col md:items-center">
+          <PostHogPageView />
+          <TopNavbar />
+          <main className="mt-4 flex flex-col px-6 py-10 sm:px-4 md:w-[768px]">{children}</main>
+          <Footer />
+        </body>
+      </AnalyticsProvider>
+    </html>
   )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,20 +1,19 @@
 'use client'
 
-/* cspell:disable */
-
-// eslint-disable-next-line import/no-named-as-default
+// cspell:disable-next-line
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
+import { type PropsWithChildren, useEffect } from 'react'
 
-// TODO: https://linear.app/jdub/issue/JDUB-31/migrate-to-new-posthog-setup
-if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    api_host: '/ingest', // ? NOTE: Next.js will rewrite this to posthog servers. This helps get around analytics blockers.
-    ui_host: 'https://us.posthog.com',
-    capture_pageview: false, // Disable automatic pageview capture, as we capture manually
-  })
-}
+export function AnalyticsProvider({ children }: PropsWithChildren) {
+  useEffect(() => {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+      api_host: '/ingest', // ? NOTE: Next.js will rewrite this to posthog servers. This helps get around analytics blockers.
+      ui_host: 'https://us.posthog.com',
+      person_profiles: 'identified_only',
+      capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+    })
+  }, [])
 
-export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,7 +11,7 @@ export function AnalyticsProvider({ children }: PropsWithChildren) {
       api_host: '/ingest', // ? NOTE: Next.js will rewrite this to posthog servers. This helps get around analytics blockers.
       ui_host: 'https://us.posthog.com',
       person_profiles: 'identified_only',
-      capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+      capture_pageview: false, // Disable automatic pageview capture, as we capture manually in `PosthogPageView`.
     })
   }, [])
 

--- a/app/tests/layout.test.tsx
+++ b/app/tests/layout.test.tsx
@@ -30,8 +30,22 @@ const TestComponent = () => {
 }
 
 describe('RootLayout', () => {
+  beforeAll(() => {
+    // ? NOTE: This is here because of `validateDOMNesting` warnings that come from testing layout.tsx files. @see https://github.com/testing-library/react-testing-library/issues/1250.
+    // ? NOTE: Should be able to fix for this in RTL + React 19.
+    vi.stubGlobal('console', { ...console, warn: vi.fn(), log: vi.fn(), error: vi.fn() })
+  })
+
   beforeEach(() => {
     vi.mocked(usePathname).mockReturnValueOnce('/')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals() // Restore all global stubs
   })
 
   it('displays the TopNavBar', async () => {

--- a/app/tests/layout.test.tsx
+++ b/app/tests/layout.test.tsx
@@ -18,9 +18,11 @@ vi.mock('next/navigation', () => ({
   ...vi.importActual('next/navigation'),
   usePathname: vi.fn(),
 }))
-// TODO: migrate to latest posthog setup @see https://linear.app/jdub/issue/JDUB-31/migrate-to-new-posthog-setup
 vi.mock('../providers', () => ({
-  AnalyticsProvider: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  AnalyticsProvider: ({ children }: PropsWithChildren) => children,
+}))
+vi.mock('../PostHogPageView', () => ({
+  default: (_props: unknown) => null,
 }))
 
 const TestComponent = () => {

--- a/app/tests/providers.test.tsx
+++ b/app/tests/providers.test.tsx
@@ -35,6 +35,7 @@ describe('providers', () => {
     expect(posthog.init).toHaveBeenCalledWith(MOCK_NEXT_PUBLIC_POSTHOG_KEY, {
       api_host: '/ingest',
       ui_host: 'https://us.posthog.com',
+      person_profiles: 'identified_only',
       capture_pageview: false,
     })
   })


### PR DESCRIPTION
## Brief Context

- Updates implementation of `posthog` to be compliant with current README
- Adds `PostHogPageView` which was missing previoiusly.
- Stubs console.log warnings around `validateDOMNesting` until I can upgrade to `react 19x` see [stackoverflow link](https://stackoverflow.com/questions/67700090/warning-validatedomnesting-body-cannot-appear-as-a-child-of-div-in-re).
